### PR TITLE
Suport for sbt corss-scala builds

### DIFF
--- a/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
+++ b/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
@@ -69,7 +69,7 @@ abstract class AbstractPlayCrossCompilation(
     unmanagedResourceDirectories in Test += {
       (sourceDirectory in Test).value / playDir / "resources"
     },
-    crossScalaVersions ~= playCorssScalaBuilds
+    crossScalaVersions ~= playCrossScalaBuilds
   )
 
   private lazy val releaseSuffix, playDir =

--- a/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
+++ b/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
@@ -51,7 +51,7 @@ abstract class AbstractPlayCrossCompilation(
     )
 
   def playCrossScalaBuilds(scalaVersions: Seq[String]) = playVersion match {
-    case Play25 => scalaVersions.filter(version => version.startsWith("2.11") || version.startsWith("2.10"))
+    case Play25 => scalaVersions.filter(version => version.startsWith("2.11"))
     case _ => scalaVersions
   }
 

--- a/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
+++ b/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
@@ -50,7 +50,7 @@ abstract class AbstractPlayCrossCompilation(
       }
     )
 
-  def playCorssScalaBuilds(scalaVersions: Seq[String]) = playVersion match {
+  def playCrossScalaBuilds(scalaVersions: Seq[String]) = playVersion match {
     case Play25 => scalaVersions.filter(version => version.startsWith("2.11") || version.startsWith("2.10"))
     case _ => scalaVersions
   }

--- a/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
+++ b/src/main/scala/uk/gov/hmrc/playcrosscompilation/AbstractPlayCrossCompilation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ abstract class AbstractPlayCrossCompilation(
       }
     )
 
+  def playCorssScalaBuilds(scalaVersions: Seq[String]) = playVersion match {
+    case Play25 => scalaVersions.filter(version => version.startsWith("2.11") || version.startsWith("2.10"))
+    case _ => scalaVersions
+  }
+
   lazy val playCrossCompilationSettings = Seq(
     version ~= updateVersion,
     unmanagedSourceDirectories in Compile += {
@@ -63,7 +68,8 @@ abstract class AbstractPlayCrossCompilation(
     },
     unmanagedResourceDirectories in Test += {
       (sourceDirectory in Test).value / playDir / "resources"
-    }
+    },
+    crossScalaVersions ~= playCorssScalaBuilds
   )
 
   private lazy val releaseSuffix, playDir =


### PR DESCRIPTION
2.5 supports only versions 2.10.x and 2.11.x
any other version has unafact list